### PR TITLE
Lock Implementation for endpoints that send emails

### DIFF
--- a/backend/anudesh_backend/locks.py
+++ b/backend/anudesh_backend/locks.py
@@ -98,10 +98,10 @@ class Lock:
             raise LockException(f"Error getting remaining time for lock: {str(e)}")
 
 
-# testing
-if __name__ == '__main__':
-    user_id = "user123"
-    task_name = "task1"
+# # testing
+# if __name__ == '__main__':
+#     user_id = "user123"
+#     task_name = "task1"
 #
 #     #test 1
 #     lock = Lock(user_id, task_name)
@@ -115,19 +115,19 @@ if __name__ == '__main__':
 #
 #     lock.releaseLock()
 #     print(f"after releasing the lock the lock status is {lock.lockStatus()}")
-
-    #test2 part 1
-    lock = Lock(user_id, task_name)
-    print(f"Before setting the lock for 200sec the lock status is {lock.lockStatus()}")
-    lock.setLock(200)
-    print(f"Just after setting the lock for 200sec the lock status is {lock.lockStatus()}")
-
-    #test2 part2
-    lock = Lock(user_id, task_name)
-    print(f"few seconds after setting the lock for 200sec the lock status is {lock.lockStatus()}")
-
-    # #test 3 for testing remanining time
-    # lock =Lock(user_id,task_name)
-    # lock.setLock(100)
-    # time.sleep(10)
-    # print(f"remaining time = {lock.getRemainingTimeForLock()}")
+#
+#     #test2 part 1
+#     lock = Lock(user_id, task_name)
+#     print(f"Before setting the lock for 200sec the lock status is {lock.lockStatus()}")
+#     lock.setLock(200)
+#     print(f"Just after setting the lock for 200sec the lock status is {lock.lockStatus()}")
+#
+#     #test2 part2
+#     lock = Lock(user_id, task_name)
+#     print(f"few seconds after setting the lock for 200sec the lock status is {lock.lockStatus()}")
+#
+#     #test 3 for testing remanining time
+#     lock =Lock(user_id,task_name)
+#     lock.setLock(100)
+#     time.sleep(10)
+#     print(f"remaining time = {lock.getRemainingTimeForLock()}")

--- a/backend/anudesh_backend/locks.py
+++ b/backend/anudesh_backend/locks.py
@@ -1,0 +1,133 @@
+import os
+import json
+import redis
+import time
+from dotenv import load_dotenv
+
+"""
+The locks are stored in redis with the format
+userid: {
+    taskname1:validity,
+    taskname2:validity
+}
+userid is the key in redis, and the python dictionary is stored as a JSON string
+"""
+
+
+class LockException(Exception):
+    pass
+
+
+class Lock:
+    def __init__(self, user_id, task_name):
+        load_dotenv()
+        self.redis_host = os.getenv("REDIS_HOST")
+        self.redis_port = os.getenv("REDIS_PORT")
+        self.redis_connection = redis.StrictRedis(
+            host=self.redis_host, port=self.redis_port, db=0
+        )
+        self.user_id = user_id
+        self.task_name = task_name
+        # self.logger = logging.getLogger(f"Lock-{self.user_id}-{self.task_name}")
+        # self.logger.setLevel(logging.INFO)
+
+    # Return 1 if the lock is set and 0 if lock is not set
+    def lockStatus(self):
+        try:
+            retrieved_json_str = self.redis_connection.get(self.user_id)
+            if retrieved_json_str:
+                retrieved_dict = json.loads(retrieved_json_str.decode("utf-8"))
+                if self.task_name in retrieved_dict:
+                    validity = retrieved_dict[self.task_name]
+                    if time.time() > validity:
+                        return 0  # Lock has expired
+                    else:
+                        return 1  # Lock is valid
+                else:
+                    return 0  # Task name doesn't exist in locks
+            else:
+                return 0  # user id doesn't exist in Redis
+        except Exception as e:
+            raise LockException(f"Error setting lock: {str(e)}")
+
+    def setLock(self, timeout):
+        try:
+            if self.lockStatus() == 0:
+                retrieved_json_str = self.redis_connection.get(self.user_id)
+                if retrieved_json_str:
+                    # JSON for user already exists, append the task name and validity
+                    retrieved_dict = json.loads(retrieved_json_str.decode("utf-8"))
+                    retrieved_dict[self.task_name] = time.time() + timeout
+                    new_json_str = json.dumps(retrieved_dict)
+                    self.redis_connection.set(self.user_id, new_json_str)
+                    # self.logger.info(f"Lock set for task {self.task_name} and user {self.user_id} for {timeout} seconds")
+
+                else:
+                    # create new JSON for redis entry
+                    new_dict = {self.task_name: time.time() + timeout}
+                    new_json_str = json.dumps(new_dict)
+                    self.redis_connection.set(self.user_id, new_json_str)
+                    # self.logger.info(f"Lock set for task {self.task_name} and user {self.user_id} for {timeout} seconds")
+        except Exception as e:
+            raise LockException(f"Error setting lock: {str(e)}")
+
+    def releaseLock(self):
+        try:
+            if self.lockStatus() == 1:
+                retrieved_json_str = self.redis_connection.get(self.user_id)
+                retrieved_dict = json.loads(retrieved_json_str.decode("utf-8"))
+                if len(retrieved_dict) > 1:
+                    del retrieved_dict[self.task_name]
+                    new_json_str = json.dumps(retrieved_dict)
+                    self.redis_connection.set(self.user_id, new_json_str)
+                    # self.logger.info(f"Lock released for task {self.task_name} and user {self.user_id}")
+                else:
+                    self.redis_connection.delete(self.user_id)
+                    # self.logger.info(f"Lock released for task {self.task_name} and user {self.user_id}")
+        except Exception as e:
+            raise LockException(f"Error releasing lock: {str(e)}")
+
+    def getRemainingTimeForLock(self):
+        try:
+            if self.lockStatus() == 1:
+                retrieved_json_str = self.redis_connection.get(self.user_id)
+                retrieved_dict = json.loads(retrieved_json_str.decode("utf-8"))
+                remaining_time = retrieved_dict[self.task_name] - time.time()
+                return remaining_time
+        except Exception as e:
+            raise LockException(f"Error getting remaining time for lock: {str(e)}")
+
+
+# testing
+if __name__ == '__main__':
+    user_id = "user123"
+    task_name = "task1"
+#
+#     #test 1
+#     lock = Lock(user_id, task_name)
+#     print(f"Before setting the lock the lock status is {lock.lockStatus()}")
+#
+#     lock.setLock(30)
+#     print(f"After setting the lock the lock status is {lock.lockStatus()}")
+#
+#     time.sleep(31)
+#     print(f"After waiting 30sec the lock status is {lock.lockStatus()}")
+#
+#     lock.releaseLock()
+#     print(f"after releasing the lock the lock status is {lock.lockStatus()}")
+
+    #test2 part 1
+    lock = Lock(user_id, task_name)
+    print(f"Before setting the lock for 200sec the lock status is {lock.lockStatus()}")
+    lock.setLock(200)
+    print(f"Just after setting the lock for 200sec the lock status is {lock.lockStatus()}")
+
+    #test2 part2
+    lock = Lock(user_id, task_name)
+    print(f"few seconds after setting the lock for 200sec the lock status is {lock.lockStatus()}")
+
+    # #test 3 for testing remanining time
+    # lock =Lock(user_id,task_name)
+    # lock.setLock(100)
+    # time.sleep(10)
+    # print(f"remaining time = {lock.getRemainingTimeForLock()}")

--- a/backend/functions/tasks.py
+++ b/backend/functions/tasks.py
@@ -30,7 +30,7 @@ from tasks.models import (
 from tasks.views import SentenceOperationViewSet
 from users.models import User
 from django.core.mail import EmailMessage
-
+from anudesh_backend.locks import Lock
 from utils.blob_functions import (
     extract_account_name,
     extract_account_key,
@@ -721,6 +721,20 @@ def schedule_mail_for_project_reports(
     did,
     language,
 ):
+    task_name = (
+            "schedule_mail_for_project_reports"
+            + str(project_type)
+            + str(anno_stats)
+            + str(meta_stats)
+            + str(complete_stats)
+            + str(workspace_level_reports)
+            + str(organization_level_reports)
+            + str(dataset_level_reports)
+            + str(wid)
+            + str(oid)
+            + str(did)
+            + str(language)
+    )
     proj_objs = get_proj_objs(
         workspace_level_reports,
         organization_level_reports,
@@ -732,6 +746,11 @@ def schedule_mail_for_project_reports(
         language,
     )
     if len(proj_objs) == 0:
+        celery_lock = Lock(user_id, task_name)
+        try:
+            celery_lock.releaseLock()
+        except Exception as e:
+            print(f"Error while releasing the lock for {task_name}: {str(e)}")
         print("No projects found")
         return 0
     user = User.objects.get(id=user_id)
@@ -780,6 +799,11 @@ def schedule_mail_for_project_reports(
         email.send()
     except Exception as e:
         print(f"An error occurred while sending email: {e}")
+    celery_lock = Lock(user_id, task_name)
+    try:
+        celery_lock.releaseLock()
+    except Exception as e:
+        print(f"Error while releasing the lock for {task_name}: {str(e)}")
     print(f"Email sent successfully - {user_id}")
 
 

--- a/backend/functions/tasks.py
+++ b/backend/functions/tasks.py
@@ -722,18 +722,18 @@ def schedule_mail_for_project_reports(
     language,
 ):
     task_name = (
-            "schedule_mail_for_project_reports"
-            + str(project_type)
-            + str(anno_stats)
-            + str(meta_stats)
-            + str(complete_stats)
-            + str(workspace_level_reports)
-            + str(organization_level_reports)
-            + str(dataset_level_reports)
-            + str(wid)
-            + str(oid)
-            + str(did)
-            + str(language)
+        "schedule_mail_for_project_reports"
+        + str(project_type)
+        + str(anno_stats)
+        + str(meta_stats)
+        + str(complete_stats)
+        + str(workspace_level_reports)
+        + str(organization_level_reports)
+        + str(dataset_level_reports)
+        + str(wid)
+        + str(oid)
+        + str(did)
+        + str(language)
     )
     proj_objs = get_proj_objs(
         workspace_level_reports,
@@ -1465,6 +1465,13 @@ def get_most_recent_annotation(annotation):
 def schedule_mail_to_download_all_projects(
     self, workspace_level_projects, dataset_level_projects, wid, did, user_id
 ):
+    task_name = (
+        "schedule_mail_to_download_all_projects"
+        + str(workspace_level_projects)
+        + str(dataset_level_projects)
+        + str(wid)
+        + str(did)
+    )
     download_lock = threading.Lock()
     download_lock.acquire()
     proj_objs = get_proj_objs(
@@ -1478,9 +1485,19 @@ def schedule_mail_to_download_all_projects(
     )
     if len(proj_objs) == 0 and workspace_level_projects:
         print(f"No projects found for workspace id- {wid}")
+        celery_lock = Lock(user_id, task_name)
+        try:
+            celery_lock.releaseLock()
+        except Exception as e:
+            print(f"Error while releasing the lock for {task_name}: {str(e)}")
         return 0
     elif len(proj_objs) == 0 and dataset_level_projects:
         print(f"No projects found for dataset id- {did}")
+        celery_lock = Lock(user_id, task_name)
+        try:
+            celery_lock.releaseLock()
+        except Exception as e:
+            print(f"Error while releasing the lock for {task_name}: {str(e)}")
         return 0
     user = User.objects.get(id=user_id)
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -1525,9 +1542,19 @@ def schedule_mail_to_download_all_projects(
             print(f"An error occurred while sending email: {e}")
             return 0
         download_lock.release()
+        celery_lock = Lock(user_id, task_name)
+        try:
+            celery_lock.releaseLock()
+        except Exception as e:
+            print(f"Error while releasing the lock for {task_name}: {str(e)}")
         print(f"Email sent successfully - {user_id}")
     else:
         download_lock.release()
+        celery_lock = Lock(user_id, task_name)
+        try:
+            celery_lock.releaseLock()
+        except Exception as e:
+            print(f"Error while releasing the lock for {task_name}: {str(e)}")
         print(url)
 
 

--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -700,18 +700,18 @@ def schedule_project_reports_email(request):
     # name of the task is the same as the name of the celery function + all the parameters that are passed to it
     uid = request.user.id
     task_name = (
-            "schedule_mail_for_project_reports"
-            + str(project_type)
-            + str(anno_stats)
-            + str(meta_stats)
-            + str(complete_stats)
-            + str(workspace_level_reports)
-            + str(organization_level_reports)
-            + str(dataset_level_reports)
-            + str(wid)
-            + str(oid)
-            + str(did)
-            + str(language)
+        "schedule_mail_for_project_reports"
+        + str(project_type)
+        + str(anno_stats)
+        + str(meta_stats)
+        + str(complete_stats)
+        + str(workspace_level_reports)
+        + str(organization_level_reports)
+        + str(dataset_level_reports)
+        + str(wid)
+        + str(oid)
+        + str(did)
+        + str(language)
     )
     celery_lock = Lock(uid, task_name)
     try:
@@ -722,8 +722,7 @@ def schedule_project_reports_email(request):
         )
         lock_status = 0  # if lock status is not received successfully, it is assumed that the lock doesn't exist
 
-
-    if lock_status==0:
+    if lock_status == 0:
         celery_lock_timeout = int(os.getenv("DEFAULT_CELERY_LOCK_TIMEOUT"))
         try:
             celery_lock.setLock(celery_lock_timeout)
@@ -808,12 +807,50 @@ def download_all_projects(request):
         }
         return Response(final_response, status=status.HTTP_401_UNAUTHORIZED)
 
-    schedule_mail_to_download_all_projects.delay(
-        workspace_level_projects, dataset_level_projects, wid, did, user_id
+    # Checking lock status, name parameter of the lock is the name of the celery function + all of it's parameters in string form
+    task_name = (
+        "schedule_mail_to_download_all_projects"
+        + str(workspace_level_projects)
+        + str(dataset_level_projects)
+        + str(wid)
+        + str(did)
     )
 
-    return Response(
-        {"message": "You will receive an email with the download link shortly"},
-        status=status.HTTP_200_OK,
-    )
-    pass
+    celery_lock = Lock(user_id, task_name)
+    try:
+        lock_status = celery_lock.lockStatus()
+    except Exception as e:
+        print(
+            f"Error while retrieving the status of the lock for {task_name} : {str(e)}"
+        )
+        lock_status = 0  # if lock status is not received successfully, it is assumed that the lock doesn't exist
+
+    if lock_status == 0:
+        schedule_mail_to_download_all_projects.delay(
+            workspace_level_projects=workspace_level_projects,
+            dataset_level_projects=dataset_level_projects,
+            wid=wid,
+            did=did,
+            user_id=user_id,
+        )
+
+        return Response(
+            {"message": "You will receive an email with the download link shortly"},
+            status=status.HTTP_200_OK,
+        )
+        pass
+    else:
+        try:
+            remaining_time = celery_lock.getRemainingTimeForLock()
+        except Exception as e:
+            print(f"Error while retrieving the lock remaining time for {task_name}")
+            return Response(
+                {"message": f"Your request is already being worked upon"},
+                status=status.HTTP_200_OK,
+            )
+        return Response(
+            {
+                "message": f"Your request is already being worked upon, you can try again after {remaining_time}"
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -1,5 +1,6 @@
 import ast
 import json
+from anudesh_backend.locks import Lock
 from urllib import request
 
 from dataset import models as dataset_models
@@ -696,25 +697,73 @@ def schedule_project_reports_email(request):
     except KeyError:
         language = "NULL"
 
-    schedule_mail_for_project_reports.delay(
-        project_type,
-        user_id,
-        anno_stats,
-        meta_stats,
-        complete_stats,
-        workspace_level_reports,
-        organization_level_reports,
-        dataset_level_reports,
-        wid,
-        oid,
-        did,
-        language,
+    # name of the task is the same as the name of the celery function + all the parameters that are passed to it
+    uid = request.user.id
+    task_name = (
+            "schedule_mail_for_project_reports"
+            + str(project_type)
+            + str(anno_stats)
+            + str(meta_stats)
+            + str(complete_stats)
+            + str(workspace_level_reports)
+            + str(organization_level_reports)
+            + str(dataset_level_reports)
+            + str(wid)
+            + str(oid)
+            + str(did)
+            + str(language)
     )
+    celery_lock = Lock(uid, task_name)
+    try:
+        lock_status = celery_lock.lockStatus()
+    except Exception as e:
+        print(
+            f"Error while retrieving the status of the lock for {task_name} : {str(e)}"
+        )
+        lock_status = 0  # if lock status is not received successfully, it is assumed that the lock doesn't exist
 
-    return Response(
-        {"message": "You will receive an email with the reports shortly"},
-        status=status.HTTP_200_OK,
-    )
+
+    if lock_status==0:
+        celery_lock_timeout = int(os.getenv("DEFAULT_CELERY_LOCK_TIMEOUT"))
+        try:
+            celery_lock.setLock(celery_lock_timeout)
+        except Exception as e:
+            print(f"Error while setting the lock for {task_name}: {str(e)}")
+
+        schedule_mail_for_project_reports.delay(
+            project_type,
+            user_id,
+            anno_stats,
+            meta_stats,
+            complete_stats,
+            workspace_level_reports,
+            organization_level_reports,
+            dataset_level_reports,
+            wid,
+            oid,
+            did,
+            language,
+        )
+
+        return Response(
+            {"message": "You will receive an email with the reports shortly"},
+            status=status.HTTP_200_OK,
+        )
+    else:
+        try:
+            remaining_time = celery_lock.getRemainingTimeForLock()
+        except Exception as e:
+            print(f"Error while retrieving the lock remaining time for {task_name}")
+            return Response(
+                {"message": f"Your request is already being worked upon"},
+                status=status.HTTP_200_OK,
+            )
+        return Response(
+            {
+                "message": f"Your request is already being worked upon, you can try again after {remaining_time}"
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 @api_view(["POST"])

--- a/backend/workspaces/tasks.py
+++ b/backend/workspaces/tasks.py
@@ -527,6 +527,12 @@ def send_project_analysis_reports_mail_ws(
     tgt_language,
     project_type,
 ):
+    task_name = (
+        "send_project_analysis_reports_mail_ws"
+        + str(pk)
+        + str(tgt_language)
+        + str(project_type)
+    )
     ws = Workspace.objects.get(pk=pk)
     user = User.objects.get(id=user_id)
     try:
@@ -896,6 +902,11 @@ def send_project_analysis_reports_mail_ws(
         attachments=[(filename, content, content_type)],
     )
     email.send()
+    celery_lock = Lock(user_id, task_name)
+    try:
+        celery_lock.releaseLock()
+    except Exception as e:
+        print(f"Error while releasing the lock for {task_name}: {str(e)}")
 
 
 def get_supercheck_reports(proj_ids, userid, start_date, end_date, project_type=None):

--- a/backend/workspaces/tasks.py
+++ b/backend/workspaces/tasks.py
@@ -333,8 +333,14 @@ def send_user_reports_mail_ws(
     end_date=None,
     period=None,
 ):
-    task_name = "send_user_reports_mail_ws" + str(ws_id) + str(project_type) + str(participation_types) + str(
-        start_date) + str(end_date)
+    task_name = (
+        "send_user_reports_mail_ws"
+        + str(ws_id)
+        + str(project_type)
+        + str(participation_types)
+        + str(start_date)
+        + str(end_date)
+    )
     """Function to generate CSV of workspace user reports and send mail to the manager/owner/admin
 
     Args:
@@ -1652,6 +1658,17 @@ def send_user_analysis_reports_mail_ws(
     is_translation_project,
     reports_type,
 ):
+    task_name = (
+        "send_user_analysis_reports_mail_ws"
+        + str(pk)
+        + str(tgt_language)
+        + str(project_type)
+        + str(project_progress_stage)
+        + str(start_date)
+        + str(end_date)
+        + str(is_translation_project)
+        + str(reports_type)
+    )
     ws = Workspace.objects.get(pk=pk)
     user = User.objects.get(id=user_id)
     final_reports = []
@@ -2049,4 +2066,9 @@ def send_user_analysis_reports_mail_ws(
         [user.email],
         attachments=[(filename, content, content_type)],
     )
+    celery_lock = Lock(user_id, task_name)
+    try:
+        celery_lock.releaseLock()
+    except Exception as e:
+        print(f"Error while releasing the lock for {task_name}: {str(e)}")
     email.send()


### PR DESCRIPTION
# Added Locks
- The locking mechanism has been carried forward from Shoonya
- Locks have been added to only the endpoints that call a celery task to send email
- All locks are stored in Redis
- This implementation is fail safe, i.e in case of any failure in this mechanism the normal functioning of neither the task nor the endpoint is hindered

# Modified endpoints and tasks

| `Enpoint` | `Celery Task` | `Django App` |
| ---- | ---- | ---- |
| project_analytics | send_project_analysis_reports_mail_ws | workspaces |
| user_analytics | send_user_analysis_reports_mail_ws | workspaces |
| send_user_analytics | send_user_reports_mail_ws | workspaces |
| download_all_projects | schedule_mail_to_download_all_projects | functions |
| schedule_project_reports_email | schedule_mail_for_project_reports | functions |

# Env variables required
```
REDIS_HOST=
REDIS_PORT=
DEFAULT_CELERY_LOCK_TIMEOUT=
```
- Note: the `DEFAULT_CELERY_LOCK_TIMEOUT` takes in values in seconds
