### PR TITLE
feat: make system_prompt configurable from project metadata

### DIFF
--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -365,14 +365,18 @@ def chat_log(request):
 @permission_classes([AllowAny])
 @api_view(["POST"])
 def chat_output(request):
+    DEFAULT_SYSTEM_PROMPT = (
+        "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or "
+        "bullet or numberings etc. suitably for code or the text. wherever required."
+    )
     prompt = request.data.get("message")
     history = request.data.get("history", "")
     model = request.data.get("model", "GPT3.5")
+    system_prompt = (request.data.get("system_prompt", "") or "").strip() or DEFAULT_SYSTEM_PROMPT
     return Response(
         {
             "message": get_model_output(
-                "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or "
-                "bullet or numberings etc. suitably for code or the text. wherever required.",
+                system_prompt,
                 prompt,
                 history,
                 model,

--- a/backend/projects/models.py
+++ b/backend/projects/models.py
@@ -281,6 +281,29 @@ class Project(models.Model):
         ),
     )
 
+    max_Draft_tasks_per_user = models.IntegerField(
+        verbose_name="max draft tasks per user",
+        default=-1,
+        help_text=(
+            "Maximum number of draft tasks that can be assigned to a user. Default is -1, which means unlimited"
+        ),
+    )
+
+    max_Skipped_tasks_per_user = models.IntegerField(
+        verbose_name="max skipped tasks per user",
+        default=-1,
+        help_text=(
+            "Maximum number of skipped tasks allowed per user. Default is -1, which means unlimited"
+        ),
+    )
+
+    preferred_annotators = models.JSONField(
+        verbose_name="preferred annotators",
+        null=True,
+        blank=True,
+        help_text=("List of preferred annotators for the project"),
+    )
+
     def clear_expired_lock(self):
         self.lock.filter(expires_at__lt=now()).delete()
 

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -2982,11 +2982,19 @@ def get_llm_output(prompt, task, annotation, project_metadata_json):
         dup_check = duplicate_check(ann_result, prompt)
 
     # GET MODEL OUTPUT
+    DEFAULT_SYSTEM_PROMPT = (
+        "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or "
+        "bullet or numberings etc. suitably for code or the text. wherever required."
+    )
+    system_prompt = (
+        project_metadata.get("system_prompt", "").strip()
+        if isinstance(project_metadata, dict)
+        else ""
+    ) or DEFAULT_SYSTEM_PROMPT
     history = ann_result
     model = task.data["model"]
     model_output = get_model_output(
-        "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or "
-        "bullet or numberings etc. suitably for code or the text. wherever required.",
+        system_prompt,
         prompt,
         history,
         model,
@@ -3041,12 +3049,20 @@ def get_all_llm_output(prompt, task, annotation, project_metadata_json, models_t
         dup_check = duplicate_check(ann_result, prompt)
 
     # GET MODEL OUTPUT
+    DEFAULT_SYSTEM_PROMPT = (
+        "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or "
+        "bullet or numberings etc. suitably for code or the text. wherever required."
+    )
+    system_prompt = (
+        project_metadata.get("system_prompt", "").strip()
+        if isinstance(project_metadata, dict)
+        else ""
+    ) or DEFAULT_SYSTEM_PROMPT
     history = ann_result[0]
 
 
     model_output = get_all_model_output(
-        "We will be rendering your response on a frontend. so please add spaces or indentation or nextline chars or "
-        "bullet or numberings etc. suitably for code or the text. wherever required.",
+        system_prompt,
         prompt,
         history,
         models_to_run


### PR DESCRIPTION
#### Summary

The LLM `system_prompt` was previously hardcoded across the codebase. This PR makes it configurable per-project by reading it from `metadata_json`, with a fallback to the existing default prompt.

#### Changes

**`backend/tasks/views.py`**
- Updated `get_llm_output()` to read `system_prompt` from `project_metadata` instead of using a hardcoded string.
- Updated `get_all_llm_output()` with the same logic.
- Both functions fall back to the default prompt if `system_prompt` is missing or empty.

**`backend/functions/views.py`**
- Updated `chat_output()` to accept an optional `system_prompt` field from the request body, with fallback to default.

**`backend/projects/models.py`**
- Added missing model fields to match the database schema:
  - `max_Draft_tasks_per_user` (IntegerField, default=-1)
  - `max_Skipped_tasks_per_user` (IntegerField, default=-1)
  - `preferred_annotators` (JSONField, nullable)

#### How it works

```python
# Reads from project metadata, falls back to default
DEFAULT_SYSTEM_PROMPT = (
    "We will be rendering your response on a frontend. so please add spaces ..."
)
system_prompt = (
    project_metadata.get("system_prompt", "").strip()
    if isinstance(project_metadata, dict)
    else ""
) or DEFAULT_SYSTEM_PROMPT
```

#### Testing

- ✅ Verified project creation with a custom system prompt stores it in `metadata_json`
- ✅ Verified LLM interactions use the configured prompt
- ✅ Verified fallback to default when `system_prompt` is not set

#### Notes

> The `system_prompt` is stored inside the existing `metadata_json` JSONField — **no new database migration is required** for the system prompt itself. The model field additions (`max_Draft_tasks_per_user`, etc.) resolve a pre-existing schema mismatch with the remote database.