### PR TITLE
Implement async LLM calls via Celery background tasks

### DIFF
--- a/backend/anudesh_backend/celery.py
+++ b/backend/anudesh_backend/celery.py
@@ -14,6 +14,7 @@ celery_app = Celery(
     result_serializer="json",
     task_serializer="json",
     result_expires=None,
+    include=["tasks.llm_tasks"],
 )
 # Celery settings
 celery_app.config_from_object("django.conf:settings", namespace="CELERY")
@@ -24,6 +25,7 @@ celery_app.conf.task_default_queue = "default"
 celery_app.conf.task_routes = {
     "functions.tasks.*": {"queue": "functions"},
     "reports.tasks.*": {"queue": "reports"},
+    "tasks.llm_tasks.*": {"queue": "llm"},
 }
 
 # Celery Beat tasks registration

--- a/backend/anudesh_backend/urls.py
+++ b/backend/anudesh_backend/urls.py
@@ -12,6 +12,7 @@ from tasks.views import (
     AnnotationViewSet,
     PredictionViewSet,
     SentenceOperationViewSet,
+    llm_task_status,
 )
 
 
@@ -44,6 +45,7 @@ urlpatterns = [
     path("workspaces/", include("workspaces.urls")),
     # path("/", include("tasks.urls")),
     path("tasks/", include("tasks.urls")),
+    path("annotation/llm_task_status/<str:celery_task_id>/", llm_task_status),
     path("notifications/", include("notifications.urls")),
     path("projects/", include("projects.urls")),
     path("functions/", include("functions.urls")),

--- a/backend/deploy/requirements-mac.txt
+++ b/backend/deploy/requirements-mac.txt
@@ -21,6 +21,7 @@ boto3==1.40.11
 botocore==1.40.11
 cachetools==5.5.2
 celery==5.3.4
+gevent==23.9.1
 certifi==2025.8.3
 cffi==1.17.1
 charset-normalizer==3.4.3

--- a/backend/deploy/requirements.txt
+++ b/backend/deploy/requirements.txt
@@ -20,6 +20,7 @@ boxing==0.1.4
 cached-property==1.5.2
 cachetools==5.3.1
 celery==5.2.2
+gevent==23.9.1
 certifi==2023.7.22
 cffi==1.15.1
 charset-normalizer==2.0.12

--- a/backend/tasks/llm_tasks.py
+++ b/backend/tasks/llm_tasks.py
@@ -9,19 +9,24 @@ def run_llm_task(self, annotation_id, prompt):
     from django.db import transaction
 
     try:
+        # Read annotation metadata outside the transaction — no DB connection held during LLM call
+        annotation_obj = Annotation.objects.select_related(
+            "task", "task__project_id"
+        ).get(id=annotation_id)
+
+        output = get_llm_output(
+            prompt,
+            annotation_obj.task,
+            annotation_obj,
+            annotation_obj.task.project_id.metadata_json,
+        )
+
+        if output in (-1, None, "Null", "None", "", " "):
+            raise Exception("LLM returned empty or invalid output")
+
+        # Re-acquire with lock only for the fast write
         with transaction.atomic():
             annotation_obj = Annotation.objects.select_for_update().get(id=annotation_id)
-
-            output = get_llm_output(
-                prompt,
-                annotation_obj.task,
-                annotation_obj,
-                annotation_obj.task.project_id.metadata_json,
-            )
-
-            if output in (-1, None, "Null", "None", "", " "):
-                raise Exception("LLM returned empty or invalid output")
-
             annotation_obj.result.append({"prompt": prompt, "output": output})
             annotation_obj.meta_stats = compute_meta_stats_for_instruction_driven_chat(
                 annotation_obj.result
@@ -43,27 +48,33 @@ def run_all_llm_task(self, annotation_id, prompt, prompt_output_pair_id):
     from rest_framework.response import Response as DRFResponse
 
     try:
+        # Read annotation metadata outside the transaction — no DB connection held during LLM call
+        annotation_obj = Annotation.objects.select_related(
+            "task", "task__project_id"
+        ).get(id=annotation_id)
+
+        output_result = get_all_llm_output(
+            prompt,
+            annotation_obj.task,
+            annotation_obj,
+            annotation_obj.task.project_id.metadata_json,
+            annotation_obj.task.data.get("model", []),
+        )
+
+        if output_result in (-1, None):
+            raise Exception("LLM returned empty or invalid output")
+        if isinstance(output_result, DRFResponse):
+            raise Exception(output_result.data.get("message", "LLM error"))
+
+        # Re-acquire with lock only for the fast write
         with transaction.atomic():
             annotation_obj = Annotation.objects.select_for_update().get(id=annotation_id)
 
             if not annotation_obj.result:
-                annotation_obj.result.append({"eval_form": [], "model_interactions": []})
+                annotation_obj.result = [{"eval_form": [], "model_interactions": []}]
             result_entry = annotation_obj.result[0]
             if "model_interactions" not in result_entry:
                 result_entry["model_interactions"] = []
-
-            output_result = get_all_llm_output(
-                prompt,
-                annotation_obj.task,
-                annotation_obj,
-                annotation_obj.task.project_id.metadata_json,
-                annotation_obj.task.data["model"],
-            )
-
-            if output_result in (-1, None):
-                raise Exception("LLM returned empty or invalid output")
-            if isinstance(output_result, DRFResponse):
-                raise Exception(output_result.data.get("message", "LLM error"))
 
             for model_name, model_output in output_result.items():
                 new_interaction = {

--- a/backend/tasks/llm_tasks.py
+++ b/backend/tasks/llm_tasks.py
@@ -1,0 +1,95 @@
+from celery import shared_task
+
+
+@shared_task(bind=True, max_retries=2, default_retry_delay=5)
+def run_llm_task(self, annotation_id, prompt):
+    from tasks.models import Annotation
+    from tasks.views import get_llm_output
+    from tasks.utils import compute_meta_stats_for_instruction_driven_chat
+    from django.db import transaction
+
+    try:
+        with transaction.atomic():
+            annotation_obj = Annotation.objects.select_for_update().get(id=annotation_id)
+
+            output = get_llm_output(
+                prompt,
+                annotation_obj.task,
+                annotation_obj,
+                annotation_obj.task.project_id.metadata_json,
+            )
+
+            if output in (-1, None, "Null", "None", "", " "):
+                raise Exception("LLM returned empty or invalid output")
+
+            annotation_obj.result.append({"prompt": prompt, "output": output})
+            annotation_obj.meta_stats = compute_meta_stats_for_instruction_driven_chat(
+                annotation_obj.result
+            )
+            annotation_obj.save(update_fields=["result", "meta_stats", "updated_at"])
+
+        return {"annotation_result": annotation_obj.result}
+
+    except Exception as exc:
+        raise self.retry(exc=exc)
+
+
+@shared_task(bind=True, max_retries=2, default_retry_delay=5)
+def run_all_llm_task(self, annotation_id, prompt, prompt_output_pair_id):
+    from tasks.models import Annotation
+    from tasks.views import get_all_llm_output
+    from tasks.utils import compute_meta_stats_for_multiple_llm_idc
+    from django.db import transaction
+    from rest_framework.response import Response as DRFResponse
+
+    try:
+        with transaction.atomic():
+            annotation_obj = Annotation.objects.select_for_update().get(id=annotation_id)
+
+            if not annotation_obj.result:
+                annotation_obj.result.append({"eval_form": [], "model_interactions": []})
+            result_entry = annotation_obj.result[0]
+            if "model_interactions" not in result_entry:
+                result_entry["model_interactions"] = []
+
+            output_result = get_all_llm_output(
+                prompt,
+                annotation_obj.task,
+                annotation_obj,
+                annotation_obj.task.project_id.metadata_json,
+                annotation_obj.task.data["model"],
+            )
+
+            if output_result in (-1, None):
+                raise Exception("LLM returned empty or invalid output")
+            if isinstance(output_result, DRFResponse):
+                raise Exception(output_result.data.get("message", "LLM error"))
+
+            for model_name, model_output in output_result.items():
+                new_interaction = {
+                    "prompt": prompt,
+                    "output": model_output,
+                    "preferred_response": False,
+                    "prompt_output_pair_id": prompt_output_pair_id,
+                }
+                model_found = False
+                for model_entry in result_entry["model_interactions"]:
+                    if model_entry.get("model_name") == model_name:
+                        model_entry["interaction_json"].append(new_interaction)
+                        model_found = True
+                        break
+                if not model_found:
+                    result_entry["model_interactions"].append({
+                        "model_name": model_name,
+                        "interaction_json": [new_interaction],
+                    })
+
+            annotation_obj.meta_stats = compute_meta_stats_for_multiple_llm_idc(
+                annotation_obj.result
+            )
+            annotation_obj.save(update_fields=["result", "meta_stats", "updated_at"])
+
+        return {"annotation_result": annotation_obj.result}
+
+    except Exception as exc:
+        raise self.retry(exc=exc)

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -7,7 +7,7 @@ from rest_framework import viewsets
 from rest_framework import mixins
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.decorators import action, api_view
+from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from django.core.paginator import Paginator
 
@@ -1798,54 +1798,18 @@ class AnnotationViewSet(
                                     "model_responses_json": eval_form_vals
                                 })
                         else:
-                            if not annotation_obj.result:
-                                annotation_obj.result.append({
-                                    "eval_form": [],
-                                    "model_interactions": []
-                                })
-                            result_entry = annotation_obj.result[0]
-                            if "model_interactions" not in result_entry:
-                                result_entry["model_interactions"] = []
-
-                            output_result = get_all_llm_output(
+                            from tasks.llm_tasks import run_all_llm_task
+                            celery_task = run_all_llm_task.delay(
+                                annotation_obj.id,
                                 request.data["result"],
-                                annotation_obj.task,
-                                annotation_obj,
-                                annotation_obj.task.project_id.metadata_json,
-                                task.data["model"]
+                                request.data.get("prompt_output_pair_id"),
                             )
-                            if output_result == -1:
-                                ret_dict = {
-                                    "message": "Please make sure you have entered a prompt and the system has responded with an answer"
-                                }
-                                ret_status = status.HTTP_403_FORBIDDEN
-                                return Response(ret_dict, status=ret_status)
-                            elif isinstance(output_result, Response):
-                                return output_result
-                            # store the result of all checks as well
-                            prompt_text = request.data["result"]
-                            for model_name, model_output in output_result.items():
-                                new_interaction = {
-                                    "prompt": prompt_text,
-                                    "output": model_output,
-                                    "preferred_response": False,
-                                    "prompt_output_pair_id": request.data['prompt_output_pair_id']
-                                }
-
-                                model_found = False
-                                for model_entry in result_entry["model_interactions"]:
-                                    if model_entry.get("model_name") == model_name:
-                                        model_entry["interaction_json"].append(new_interaction)
-                                        model_found = True
-                                        break
-
-                                # If model not found, create a new one
-                                if not model_found:
-                                    result_entry["model_interactions"].append({
-                                        "model_name": model_name,
-                                        "interaction_json": [new_interaction]
-
-                                    })  
+                            annotation_obj.lead_time = request.data["lead_time"]
+                            annotation_obj.save(update_fields=["lead_time", "updated_at"])
+                            return Response(
+                                {"celery_task_id": celery_task.id, "result": annotation_obj.result},
+                                status=status.HTTP_202_ACCEPTED,
+                            )
                     else:
                         annotation_obj.result = request.data["result"]
                         annotation_obj.meta_stats = (
@@ -1859,26 +1823,16 @@ class AnnotationViewSet(
                     == "InstructionDrivenChat"
                 ):
                     if isinstance(request.data["result"], str):
-                        output_result = get_llm_output(
+                        from tasks.llm_tasks import run_llm_task
+                        celery_task = run_llm_task.delay(
+                            annotation_obj.id,
                             request.data["result"],
-                            annotation_obj.task,
-                            annotation_obj,
-                            annotation_obj.task.project_id.metadata_json,
                         )
-                        if output_result == -1:
-                            ret_dict = {
-                                "message": "Please make sure you have entered a prompt and the system has responded with an answer"
-                            }
-                            ret_status = status.HTTP_403_FORBIDDEN
-                            return Response(ret_dict, status=ret_status)
-                        elif isinstance(output_result, Response):
-                            return output_result
-                        # store the result of all checks as well
-                        annotation_obj.result.append(
-                            {
-                                "prompt": request.data["result"],
-                                "output": output_result,
-                            }
+                        annotation_obj.lead_time = request.data["lead_time"]
+                        annotation_obj.save(update_fields=["lead_time", "updated_at"])
+                        return Response(
+                            {"celery_task_id": celery_task.id, "result": annotation_obj.result},
+                            status=status.HTTP_202_ACCEPTED,
                         )
                     # to handle the delete last chat case
                     else:
@@ -2060,54 +2014,18 @@ class AnnotationViewSet(
                                     "model_responses_json": eval_form_vals
                                 })
                         else:
-                            if not annotation_obj.result:
-                                annotation_obj.result.append({
-                                    "eval_form": [],
-                                    "model_interactions": []
-                                })
-                            result_entry = annotation_obj.result[0]
-                            if "model_interactions" not in result_entry:
-                                result_entry["model_interactions"] = []
-
-                            output_result = get_all_llm_output(
+                            from tasks.llm_tasks import run_all_llm_task
+                            celery_task = run_all_llm_task.delay(
+                                annotation_obj.id,
                                 request.data["result"],
-                                annotation_obj.task,
-                                annotation_obj,
-                                annotation_obj.task.project_id.metadata_json,
-                                task.data["model"]
+                                request.data.get("prompt_output_pair_id"),
                             )
-                            if output_result == -1:
-                                ret_dict = {
-                                    "message": "Please make sure you have entered a prompt and the system has responded with an answer"
-                                }
-                                ret_status = status.HTTP_403_FORBIDDEN
-                                return Response(ret_dict, status=ret_status)
-                            elif isinstance(output_result, Response):
-                                return output_result
-                            # store the result of all checks as well
-                            prompt_text = request.data["result"]
-                            for model_name, model_output in output_result.items():
-                                new_interaction = {
-                                    "prompt": prompt_text,
-                                    "output": model_output,
-                                    "preferred_response": False,
-                                    "prompt_output_pair_id": request.data['prompt_output_pair_id'],
-                                }
-
-                                model_found = False
-                                for model_entry in result_entry["model_interactions"]:
-                                    if model_entry.get("model_name") == model_name:
-                                        model_entry["interaction_json"].append(new_interaction)
-                                        model_found = True
-                                        break
-
-                                # If model not found, create a new one
-                                if not model_found:
-                                    result_entry["model_interactions"].append({
-                                        "model_name": model_name,
-                                        "interaction_json": [new_interaction]
-
-                                    })  
+                            annotation_obj.lead_time = request.data["lead_time"]
+                            annotation_obj.save(update_fields=["lead_time", "updated_at"])
+                            return Response(
+                                {"celery_task_id": celery_task.id, "result": annotation_obj.result},
+                                status=status.HTTP_202_ACCEPTED,
+                            )
                     else:
                         annotation_obj.result = request.data["result"]
                         annotation_obj.meta_stats = (
@@ -2121,26 +2039,16 @@ class AnnotationViewSet(
                     == "InstructionDrivenChat"
                 ):
                     if isinstance(request.data["result"], str):
-                        output_result = get_llm_output(
+                        from tasks.llm_tasks import run_llm_task
+                        celery_task = run_llm_task.delay(
+                            annotation_obj.id,
                             request.data["result"],
-                            annotation_obj.task,
-                            annotation_obj,
-                            annotation_obj.task.project_id.metadata_json,
                         )
-                        if output_result == -1:
-                            ret_dict = {
-                                "message": "Please make sure you have entered a prompt and the system has responded with an answer"
-                            }
-                            ret_status = status.HTTP_403_FORBIDDEN
-                            return Response(ret_dict, status=ret_status)
-                        elif isinstance(output_result, Response):
-                            return output_result
-                        # store the result of all checks as well
-                        annotation_obj.result.append(
-                            {
-                                "prompt": request.data["result"],
-                                "output": output_result,
-                            }
+                        annotation_obj.lead_time = request.data["lead_time"]
+                        annotation_obj.save(update_fields=["lead_time", "updated_at"])
+                        return Response(
+                            {"celery_task_id": celery_task.id, "result": annotation_obj.result},
+                            status=status.HTTP_202_ACCEPTED,
                         )
                     # to handle the delete last chat case
                     else:
@@ -2391,54 +2299,18 @@ class AnnotationViewSet(
                                     "model_responses_json": eval_form_vals
                                 })
                         else:
-                            if not annotation_obj.result:
-                                annotation_obj.result.append({
-                                    "eval_form": [],
-                                    "model_interactions": []
-                                })
-                            result_entry = annotation_obj.result[0]
-                            if "model_interactions" not in result_entry:
-                                result_entry["model_interactions"] = []
-
-                            output_result = get_all_llm_output(
+                            from tasks.llm_tasks import run_all_llm_task
+                            celery_task = run_all_llm_task.delay(
+                                annotation_obj.id,
                                 request.data["result"],
-                                annotation_obj.task,
-                                annotation_obj,
-                                annotation_obj.task.project_id.metadata_json,
-                                task.data["model"]
+                                request.data.get("prompt_output_pair_id"),
                             )
-                            if output_result == -1:
-                                ret_dict = {
-                                    "message": "Please make sure you have entered a prompt and the system has responded with an answer"
-                                }
-                                ret_status = status.HTTP_403_FORBIDDEN
-                                return Response(ret_dict, status=ret_status)
-                            elif isinstance(output_result, Response):
-                                return output_result
-                            # store the result of all checks as well
-                            prompt_text = request.data["result"]
-                            for model_name, model_output in output_result.items():
-                                new_interaction = {
-                                    "prompt": prompt_text,
-                                    "output": model_output,
-                                    "preferred_response": False,
-                                    "prompt_output_pair_id": request.data['prompt_output_pair_id'],
-                                }
-
-                                model_found = False
-                                for model_entry in result_entry["model_interactions"]:
-                                    if model_entry.get("model_name") == model_name:
-                                        model_entry["interaction_json"].append(new_interaction)
-                                        model_found = True
-                                        break
-
-                                # If model not found, create a new one
-                                if not model_found:
-                                    result_entry["model_interactions"].append({
-                                        "model_name": model_name,
-                                        "interaction_json": [new_interaction]
-
-                                    })  
+                            annotation_obj.lead_time = request.data["lead_time"]
+                            annotation_obj.save(update_fields=["lead_time", "updated_at"])
+                            return Response(
+                                {"celery_task_id": celery_task.id, "result": annotation_obj.result},
+                                status=status.HTTP_202_ACCEPTED,
+                            )
                     else:
                         annotation_obj.result = request.data["result"]
                         annotation_obj.meta_stats = (
@@ -2452,26 +2324,16 @@ class AnnotationViewSet(
                     == "InstructionDrivenChat"
                 ):
                     if isinstance(request.data["result"], str):
-                        output_result = get_llm_output(
+                        from tasks.llm_tasks import run_llm_task
+                        celery_task = run_llm_task.delay(
+                            annotation_obj.id,
                             request.data["result"],
-                            annotation_obj.task,
-                            annotation_obj,
-                            annotation_obj.task.project_id.metadata_json,
                         )
-                        if output_result == -1:
-                            ret_dict = {
-                                "message": "Please make sure you have entered a prompt and the system has responded with an answer"
-                            }
-                            ret_status = status.HTTP_403_FORBIDDEN
-                            return Response(ret_dict, status=ret_status)
-                        elif isinstance(output_result, Response):
-                            return output_result
-                        # store the result of all checks as well
-                        annotation_obj.result.append(
-                            {
-                                "prompt": request.data["result"],
-                                "output": output_result,
-                            }
+                        annotation_obj.lead_time = request.data["lead_time"]
+                        annotation_obj.save(update_fields=["lead_time", "updated_at"])
+                        return Response(
+                            {"celery_task_id": celery_task.id, "result": annotation_obj.result},
+                            status=status.HTTP_202_ACCEPTED,
                         )
                     # to handle the delete last chat case
                     else:
@@ -3113,6 +2975,20 @@ def get_celery_tasks(request):
     page_size = int(request.GET.get("page_size", 10))
     data = paginate_queryset(filtered_tasks, page_number, page_size)
     return JsonResponse(data["results"], safe=False)
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def llm_task_status(request, celery_task_id):
+    from celery.result import AsyncResult
+    task_result = AsyncResult(celery_task_id)
+    if task_result.state == "SUCCESS":
+        annotation_result = task_result.result.get("annotation_result", [])
+        return Response({"status": "SUCCESS", "result": annotation_result})
+    elif task_result.state == "FAILURE":
+        return Response({"status": "FAILURE", "result": None})
+    else:
+        return Response({"status": task_result.state, "result": None})
 
 
 class TransliterationAPIView(APIView):

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -85,6 +85,17 @@ services:
   #    - redis
   #    - web
   
+  celery-llm:
+    container_name: celery-llm
+    restart: always
+    build: ./backend
+    command: celery -A anudesh_backend.celery worker -Q llm --concurrency=100 --loglevel=info -P gevent
+    volumes:
+      - ./backend/:/usr/src/backend/
+    depends_on:
+      - redis
+      - web
+
   celery3:
     container_name: celery-reports
     restart: always


### PR DESCRIPTION
- Add tasks/llm_tasks.py with run_llm_task and run_all_llm_task shared tasks
- Replace inline LLM call sites in views.py with Celery dispatch (HTTP 202)
- Add llm_task_status polling endpoint
- Register llm queue routing and include tasks.llm_tasks in celery.py
- Add celery-llm worker service with gevent pool to docker-compose-dev.yml
- Add gevent==23.9.1 to requirements.txt and requirements-mac.txt

