### PR TITLE
Implementation of Async Streaming of LLM Responses

### DIFF
--- a/backend/anudesh_backend/settings.py
+++ b/backend/anudesh_backend/settings.py
@@ -113,6 +113,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "anudesh_backend.wsgi.application"
+ASGI_APPLICATION = "anudesh_backend.asgi.application"
 
 
 # Database

--- a/backend/deploy/requirements-mac.txt
+++ b/backend/deploy/requirements-mac.txt
@@ -229,6 +229,7 @@ ujson==5.10.0
 uritemplate==4.1.1
 urllib3==1.26.20
 user-agents==2.2.0
+uvicorn==0.30.1
 vine==5.0.0
 wcwidth==0.2.6
 webencodings==0.5.1

--- a/backend/deploy/requirements.txt
+++ b/backend/deploy/requirements.txt
@@ -193,6 +193,7 @@ ujson==5.7.0
 uritemplate==4.1.1
 urllib3==1.26.16
 user-agents==2.2.0
+uvicorn==0.30.1
 vine==5.0.0
 wcwidth==0.2.6
 whitenoise==6.5.0

--- a/backend/functions/urls.py
+++ b/backend/functions/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("download_all_projects", download_all_projects),
     path("chat_log", chat_log),
     path("chat_output", chat_output),
+    path("chat_output_stream", chat_output_stream),
     path("upload_chat_image", upload_chat_image),
 ]
 

--- a/backend/functions/urls.py
+++ b/backend/functions/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("chat_log", chat_log),
     path("chat_output", chat_output),
     path("chat_output_stream", chat_output_stream),
+    path("chat_output_stream_multi", chat_output_stream_multi),
     path("upload_chat_image", upload_chat_image),
 ]
 

--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -400,7 +400,7 @@ _CHAT_SYSTEM_PROMPT = (
 async def chat_output_stream(request):
     data = json.loads(request.body)
     prompt = data.get("message")
-    history = data.get("history", "")
+    history = data.get("history", [])
     model = data.get("model", "google/gemma-4-26B-A4B-it")
 
     async def event_stream():

--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -23,8 +23,21 @@ from users.utils import (
 
 from tasks.models import *
 from utils.blob_functions import test_container_connection
-from django.http import StreamingHttpResponse
+from django.http import StreamingHttpResponse, JsonResponse
+from asgiref.sync import sync_to_async
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken, AuthenticationFailed
 from django.views.decorators.csrf import csrf_exempt
+
+def is_request_authenticated(request):
+    try:
+        auth_tuple = JWTAuthentication().authenticate(request)
+        if auth_tuple is not None:
+            user, token = auth_tuple
+            return user.is_authenticated
+    except (InvalidToken, AuthenticationFailed):
+        pass
+    return request.user.is_authenticated
 from django.views.decorators.http import require_POST
 from utils.llm_interactions import get_model_output, stream_model_output, stream_all_models_output
 
@@ -398,12 +411,16 @@ _CHAT_SYSTEM_PROMPT = (
 @csrf_exempt
 @require_POST
 async def chat_output_stream(request):
+    if not await sync_to_async(is_request_authenticated)(request):
+        return JsonResponse({"error": "Unauthorized"}, status=401)
+
     data = json.loads(request.body)
     prompt = data.get("message")
     history = data.get("history", [])
     model = data.get("model", "google/gemma-4-26B-A4B-it")
 
     async def event_stream():
+        yield ": keep-alive\n\n"
         try:
             async for token in stream_model_output(_CHAT_SYSTEM_PROMPT, prompt, history, model):
                 yield f"data: {json.dumps({'token': token, 'model': model})}\n\n"
@@ -424,6 +441,9 @@ async def chat_output_stream_multi(request):
     SSE endpoint for streaming tokens from multiple LLM models concurrently.
     Each SSE event is tagged with the model name for frontend demultiplexing.
     """
+    if not await sync_to_async(is_request_authenticated)(request):
+        return JsonResponse({"error": "Unauthorized"}, status=401)
+
     data = json.loads(request.body)
     prompt = data.get("message")
     model_interactions = data.get("model_interactions", [])
@@ -439,6 +459,7 @@ async def chat_output_stream_multi(request):
         system_prompt_data = {"default": DEFAULT_SYSTEM_PROMPT}
 
     async def event_stream():
+        yield ": keep-alive\n\n"
         try:
             async for item in stream_all_models_output(
                 system_prompt_data, prompt, model_interactions, models, DEFAULT_SYSTEM_PROMPT

--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -23,7 +23,10 @@ from users.utils import (
 
 from tasks.models import *
 from utils.blob_functions import test_container_connection
-from utils.llm_interactions import get_model_output
+from django.http import StreamingHttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from utils.llm_interactions import get_model_output, stream_model_output
 
 from .tasks import (
     populate_draft_data_json,
@@ -384,6 +387,35 @@ def chat_output(request):
         },
         status=status.HTTP_200_OK,
     )
+
+
+_CHAT_SYSTEM_PROMPT = (
+    "We will be rendering your response on a frontend. So, please add spaces or indentation or nextline chars or "
+    "bullet or numberings etc. suitably for code or the text, wherever required."
+)
+
+
+@csrf_exempt
+@require_POST
+async def chat_output_stream(request):
+    data = json.loads(request.body)
+    prompt = data.get("message")
+    history = data.get("history", "")
+    model = data.get("model", "google/gemma-4-26B-A4B-it")
+
+    async def event_stream():
+        try:
+            async for token in stream_model_output(_CHAT_SYSTEM_PROMPT, prompt, history, model):
+                yield f"data: {json.dumps({'token': token, 'model': model})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+        yield "data: [DONE]\n\n"
+
+    response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+    response["Cache-Control"] = "no-cache"
+    response["X-Accel-Buffering"] = "no"
+    return response
+
 
 @permission_classes([IsAuthenticated])
 @api_view(["POST"])

--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -26,7 +26,7 @@ from utils.blob_functions import test_container_connection
 from django.http import StreamingHttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from utils.llm_interactions import get_model_output, stream_model_output
+from utils.llm_interactions import get_model_output, stream_model_output, stream_all_models_output
 
 from .tasks import (
     populate_draft_data_json,
@@ -407,6 +407,43 @@ async def chat_output_stream(request):
         try:
             async for token in stream_model_output(_CHAT_SYSTEM_PROMPT, prompt, history, model):
                 yield f"data: {json.dumps({'token': token, 'model': model})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+        yield "data: [DONE]\n\n"
+
+    response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+    response["Cache-Control"] = "no-cache"
+    response["X-Accel-Buffering"] = "no"
+    return response
+
+
+@csrf_exempt
+@require_POST
+async def chat_output_stream_multi(request):
+    """
+    SSE endpoint for streaming tokens from multiple LLM models concurrently.
+    Each SSE event is tagged with the model name for frontend demultiplexing.
+    """
+    data = json.loads(request.body)
+    prompt = data.get("message")
+    model_interactions = data.get("model_interactions", [])
+    models = data.get("models", [])
+
+    # Build system prompt data from project metadata
+    DEFAULT_SYSTEM_PROMPT = (
+        "We will be rendering your response on a frontend. So, please add spaces or indentation or nextline chars or "
+        "bullet or numberings etc. suitably for code or the text, wherever required."
+    )
+    system_prompt_data = data.get("system_prompt_data", {})
+    if not system_prompt_data:
+        system_prompt_data = {"default": DEFAULT_SYSTEM_PROMPT}
+
+    async def event_stream():
+        try:
+            async for item in stream_all_models_output(
+                system_prompt_data, prompt, model_interactions, models, DEFAULT_SYSTEM_PROMPT
+            ):
+                yield f"data: {json.dumps(item)}\n\n"
         except Exception as e:
             yield f"data: {json.dumps({'error': str(e)})}\n\n"
         yield "data: [DONE]\n\n"

--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -30,14 +30,53 @@ from rest_framework_simplejwt.exceptions import InvalidToken, AuthenticationFail
 from django.views.decorators.csrf import csrf_exempt
 
 def is_request_authenticated(request):
+    """
+    Authenticate a request using JWT.
+    Works with both DRF Request objects and raw Django HttpRequest
+    (used by async streaming views).
+    """
+    # First, try DRF's built-in JWTAuthentication (works with DRF Request objects)
     try:
         auth_tuple = JWTAuthentication().authenticate(request)
         if auth_tuple is not None:
             user, token = auth_tuple
             return user.is_authenticated
     except (InvalidToken, AuthenticationFailed):
+        return False
+    except Exception:
         pass
-    return request.user.is_authenticated
+
+    # Fallback: manually extract JWT from the Authorization header.
+    # This handles raw Django HttpRequest objects in async views where
+    # DRF's JWTAuthentication silently fails because it expects a DRF Request.
+    auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+    if not auth_header:
+        auth_header = request.headers.get("Authorization", "")
+
+    if auth_header:
+        parts = auth_header.split()
+        if len(parts) == 2 and parts[0].upper() == "JWT":
+            raw_token = parts[1]
+            try:
+                from rest_framework_simplejwt.tokens import UntypedToken
+                from django.contrib.auth import get_user_model
+                UntypedToken(raw_token)  # validates expiry & signature
+                # Decode to get user_id
+                from rest_framework_simplejwt.backends import TokenBackend
+                from django.conf import settings
+                tb = TokenBackend(
+                    algorithm="HS256",
+                    signing_key=settings.SECRET_KEY,
+                )
+                payload = tb.decode(raw_token, verify=True)
+                User = get_user_model()
+                user = User.objects.get(id=payload.get("user_id"))
+                return user.is_authenticated
+            except Exception:
+                return False
+
+    # Final fallback: check session-based auth
+    return getattr(request, "user", None) is not None and request.user.is_authenticated
 from django.views.decorators.http import require_POST
 from utils.llm_interactions import get_model_output, stream_model_output, stream_all_models_output
 

--- a/backend/utils/llm_interactions.py
+++ b/backend/utils/llm_interactions.py
@@ -333,11 +333,29 @@ def get_all_model_output(system_prompt_data, user_prompt, history, models_to_run
 
 # ── Async streaming generators (Django 5 + ASGI) ────────────────────────────
 
+_google_client = None
+_deepinfra_client = None
+
+def _get_google_client() -> AsyncOpenAI:
+    global _google_client
+    if _google_client is None:
+        _google_client = AsyncOpenAI(
+            api_key=os.getenv("GOOGLE_AI_STUDIO_API_KEY"),
+            base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+        )
+    return _google_client
+
+def _get_deepinfra_client() -> AsyncOpenAI:
+    global _deepinfra_client
+    if _deepinfra_client is None:
+        _deepinfra_client = AsyncOpenAI(
+            api_key=os.getenv("DEEPINFRA_API_KEY"),
+            base_url=os.getenv("DEEPINFRA_BASE_URL"),
+        )
+    return _deepinfra_client
+
 async def stream_google_ai_studio_output(system_prompt, user_prompt, history, model):
-    client = AsyncOpenAI(
-        api_key=os.getenv("GOOGLE_AI_STUDIO_API_KEY"),
-        base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
-    )
+    client = _get_google_client()
     history_messages = process_history(history)
     messages = [{"role": "system", "content": system_prompt}]
     messages.extend(history_messages)
@@ -359,10 +377,7 @@ async def stream_google_ai_studio_output(system_prompt, user_prompt, history, mo
 
 
 async def stream_deepinfra_output(system_prompt, user_prompt, history, model):
-    client = AsyncOpenAI(
-        api_key=os.getenv("DEEPINFRA_API_KEY"),
-        base_url=os.getenv("DEEPINFRA_BASE_URL"),
-    )
+    client = _get_deepinfra_client()
     history_messages = process_history(history)
     messages = [{"role": "system", "content": system_prompt}]
     messages.extend(history_messages)

--- a/backend/utils/llm_interactions.py
+++ b/backend/utils/llm_interactions.py
@@ -420,5 +420,3 @@ async def stream_model_output(system_prompt, user_prompt, history, model="google
     else:
         async for token in stream_deepinfra_output(system_prompt, user_prompt, history, model):
             yield token
-
-    return results

--- a/backend/utils/llm_interactions.py
+++ b/backend/utils/llm_interactions.py
@@ -41,7 +41,7 @@ import os
 
 
 import re
-from openai import OpenAI
+from openai import OpenAI, AsyncOpenAI
 import requests
 from rest_framework import status
 from rest_framework.response import Response
@@ -328,5 +328,97 @@ def get_all_model_output(system_prompt_data, user_prompt, history, models_to_run
 
         if isinstance(results[model], Response):
             return results[model]
+
+
+# ── Async streaming generators (Django 5 + ASGI) ────────────────────────────
+
+async def stream_google_ai_studio_output(system_prompt, user_prompt, history, model):
+    client = AsyncOpenAI(
+        api_key=os.getenv("GOOGLE_AI_STUDIO_API_KEY"),
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+    )
+    history_messages = process_history(history)
+    messages = [{"role": "system", "content": system_prompt}]
+    messages.extend(history_messages)
+    messages.append({"role": "user", "content": user_prompt})
+
+    try:
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0.7,
+            max_tokens=2048,
+            stream=True,
+        )
+        async for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content is not None:
+                yield chunk.choices[0].delta.content
+    except Exception as e:
+        yield f"[ERROR] {e}"
+
+
+async def stream_deepinfra_output(system_prompt, user_prompt, history, model):
+    client = AsyncOpenAI(
+        api_key=os.getenv("DEEPINFRA_API_KEY"),
+        base_url=os.getenv("DEEPINFRA_BASE_URL"),
+    )
+    history_messages = process_history(history)
+    messages = [{"role": "system", "content": system_prompt}]
+    messages.extend(history_messages)
+    messages.append({"role": "user", "content": user_prompt})
+
+    # State machine to strip <think>...</think> blocks that may span chunk boundaries
+    pending = ""
+    in_think = False
+
+    try:
+        stream = await client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0.7,
+            max_tokens=2048,
+            stream=True,
+        )
+        async for chunk in stream:
+            if not (chunk.choices and chunk.choices[0].delta.content is not None):
+                continue
+            pending += chunk.choices[0].delta.content
+
+            while True:
+                if in_think:
+                    end = pending.find("</think>")
+                    if end != -1:
+                        in_think = False
+                        pending = pending[end + 8:].lstrip("\n")
+                    else:
+                        pending = ""
+                        break
+                else:
+                    start = pending.find("<think>")
+                    if start != -1:
+                        if start > 0:
+                            yield pending[:start]
+                        in_think = True
+                        pending = pending[start + 7:]
+                    else:
+                        # Keep last 7 chars to handle tags split across chunks
+                        if len(pending) > 7:
+                            yield pending[:-7]
+                            pending = pending[-7:]
+                        break
+
+        if pending and not in_think:
+            yield pending.lstrip("\n")
+    except Exception as e:
+        yield f"[ERROR] {e}"
+
+
+async def stream_model_output(system_prompt, user_prompt, history, model="google/gemma-4-26B-A4B-it"):
+    if model in GOOGLE_AI_STUDIO_MODELS:
+        async for token in stream_google_ai_studio_output(system_prompt, user_prompt, history, model):
+            yield token
+    else:
+        async for token in stream_deepinfra_output(system_prompt, user_prompt, history, model):
+            yield token
 
     return results

--- a/backend/utils/llm_interactions.py
+++ b/backend/utils/llm_interactions.py
@@ -421,3 +421,56 @@ async def stream_model_output(system_prompt, user_prompt, history, model="google
     else:
         async for token in stream_deepinfra_output(system_prompt, user_prompt, history, model):
             yield token
+
+
+async def stream_all_models_output(system_prompt_data, user_prompt, model_interactions, models_to_run, default_system_prompt=""):
+    """
+    Stream tokens from multiple models concurrently.
+    Yields dicts like: {"model": "modelA", "token": "Hello"}
+    and {"model": "modelA", "done": True} when a model finishes.
+    """
+    import asyncio
+
+    queue = asyncio.Queue()
+
+    async def _stream_single_model(model_name):
+        """Collect tokens from one model and push them onto the shared queue."""
+        system_prompt = (
+            system_prompt_data.get(model_name)
+            or system_prompt_data.get("default")
+            or default_system_prompt
+        ) if isinstance(system_prompt_data, dict) else system_prompt_data
+
+        # Extract this model's conversation history from model_interactions
+        model_history = next(
+            (
+                interaction["interaction_json"]
+                for interaction in (model_interactions or [])
+                if interaction.get("model_name") == model_name
+            ),
+            [],
+        )
+
+        try:
+            async for token in stream_model_output(system_prompt, user_prompt, model_history, model_name):
+                await queue.put({"model": model_name, "token": token})
+        except Exception as e:
+            await queue.put({"model": model_name, "error": str(e)})
+        finally:
+            await queue.put({"model": model_name, "done": True})
+
+    # Launch all model streams concurrently
+    tasks = [asyncio.create_task(_stream_single_model(m)) for m in models_to_run]
+
+    models_remaining = len(models_to_run)
+    while models_remaining > 0:
+        item = await queue.get()
+        if item.get("done"):
+            models_remaining -= 1
+        yield item
+
+    # Ensure all tasks are cleaned up
+    for t in tasks:
+        if not t.done():
+            t.cancel()
+

--- a/backend/utils/llm_interactions.py
+++ b/backend/utils/llm_interactions.py
@@ -328,7 +328,8 @@ def get_all_model_output(system_prompt_data, user_prompt, history, models_to_run
 
         if isinstance(results[model], Response):
             return results[model]
-
+    
+    return results
 
 # ── Async streaming generators (Django 5 + ASGI) ────────────────────────────
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -38,7 +38,7 @@ services:
     
   web:
     build: ./backend
-    command: gunicorn --bind 0.0.0.0:8000 --workers 4 anudesh_backend.wsgi --timeout 300
+    command: gunicorn --bind 0.0.0.0:8000 --workers 4 --worker-class uvicorn.workers.UvicornWorker anudesh_backend.asgi:application --timeout 300
     volumes:
       - ./backend/:/usr/src/backend/
       - static_volume:/usr/src/backend/static


### PR DESCRIPTION
## Overview
This PR introduces real-time Server-Sent Events (SSE) streaming for LLM chat generations. By migrating from synchronous polling to an asynchronous streaming model, the application now delivers tokens instantly as they are generated by the model, vastly improving the perceived latency and UX for annotators.

## Changes Included
- **Native Async API**: Configured the `AsyncOpenAI` client for DeepInfra to natively support `stream=True`.
- **SSE Generator**: Implemented `stream_deepinfra_output` in `llm_interactions.py` as an async generator that yields chunks token-by-token.
- **Django Streaming Response**: Re-architected the `chat_output_stream` view to utilize Django 5.1's async `StreamingHttpResponse` for reliable SSE delivery.
- **Bug Fix**: Fixed a critical bug in `get_all_model_output` where a missing `return results` statement was causing an `AttributeError: 'NoneType' object has no attribute 'items'` during `PATCH` requests.

## Note on Development Server
To successfully test streaming locally, the backend must run on an ASGI server (like Uvicorn) instead of the standard Django WSGI server (`manage.py runserver`), as WSGI aggressively buffers async streams.
