### PR TITLE
Feature/update idc tasks model

### DIFF
--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1193,6 +1193,70 @@ class ProjectViewSet(viewsets.ModelViewSet):
                 {"message": f"Error: {str(e)}"},
                 status=status.HTTP_400_BAD_REQUEST
             )
+            
+    @action(detail=True, methods=["POST"], url_path="update_idc_tasks_model")
+    def update_idc_tasks_model(self, request, pk=None):
+        """
+        Update the model of all incomplete tasks in a Single IDC project if the current model is inactive.
+        """
+        from tasks.models import Task, INCOMPLETE
+        from dataset.models import ACTIVE_LLM_MODELS
+        
+        try:
+            project = self.get_object()
+            
+            # Check permissions
+            if not (request.user.role == User.ORGANIZATION_OWNER or 
+                    request.user.is_superuser or 
+                    request.user.role == User.WORKSPACE_MANAGER):
+                return Response(
+                    {"message": "You are not authorized to perform this action"},
+                    status=status.HTTP_403_FORBIDDEN
+                )
+            
+            if project.project_type != "InstructionDrivenChat":
+                return Response(
+                    {"message": "This operation is only allowed for InstructionDrivenChat projects."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+                
+            new_model = request.data.get("new_model")
+            if not new_model:
+                return Response(
+                    {"message": "new_model is required."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+                
+            if new_model not in ACTIVE_LLM_MODELS:
+                return Response(
+                    {"message": f"{new_model} is not an active LLM model."},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+                
+            tasks = Task.objects.filter(project_id=project, task_status=INCOMPLETE)
+            updated_count = 0
+            tasks_list = []
+            
+            for task in tasks:
+                current_model = task.data.get("model")
+                if current_model not in ACTIVE_LLM_MODELS:
+                    task.data["model"] = new_model
+                    tasks_list.append(task)
+                    updated_count += 1
+            
+            if tasks_list:
+                Task.objects.bulk_update(tasks_list, ['data'])
+                
+            return Response({
+                "message": f"Updated {updated_count} incomplete tasks to model {new_model}.",
+                "updated_count": updated_count
+            }, status=status.HTTP_200_OK)
+            
+        except Exception as e:
+            return Response(
+                {"message": f"Error: {str(e)}"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
     @swagger_auto_schema(
         method="get",

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1197,9 +1197,9 @@ class ProjectViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["POST"], url_path="update_idc_tasks_model")
     def update_idc_tasks_model(self, request, pk=None):
         """
-        Update the model of all incomplete tasks in a Single IDC project if the current model is inactive.
+        Update the model of incomplete tasks in a Single IDC project if the current model is inactive.
         """
-        from tasks.models import Task, INCOMPLETE
+        from tasks.models import Task, Annotation, INCOMPLETE, UNLABELED, DRAFT, SKIPPED
         from dataset.models import ACTIVE_LLM_MODELS
         
         try:
@@ -1233,7 +1233,19 @@ class ProjectViewSet(viewsets.ModelViewSet):
                     status=status.HTTP_400_BAD_REQUEST
                 )
                 
-            tasks = Task.objects.filter(project_id=project, task_status=INCOMPLETE)
+            tasks_with_progress = Annotation.objects.filter(
+                task__project_id=project
+            ).exclude(
+                annotation_status__in=[UNLABELED, DRAFT, SKIPPED]
+            ).values_list('task_id', flat=True)
+
+            tasks = Task.objects.filter(
+                project_id=project, 
+                task_status=INCOMPLETE
+            ).exclude(
+                id__in=tasks_with_progress
+            )
+            
             updated_count = 0
             tasks_list = []
             

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1199,7 +1199,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
         """
         Update the model of incomplete tasks in a Single IDC project if the current model is inactive.
         """
-        from tasks.models import Task, Annotation, INCOMPLETE, UNLABELED, DRAFT, SKIPPED
+        from tasks.models import Task, Annotation, INCOMPLETE, UNLABELED
         from dataset.models import ACTIVE_LLM_MODELS
         
         try:
@@ -1236,7 +1236,7 @@ class ProjectViewSet(viewsets.ModelViewSet):
             tasks_with_progress = Annotation.objects.filter(
                 task__project_id=project
             ).exclude(
-                annotation_status__in=[UNLABELED, DRAFT, SKIPPED]
+                annotation_status=UNLABELED
             ).values_list('task_id', flat=True)
 
             tasks = Task.objects.filter(
@@ -1258,6 +1258,20 @@ class ProjectViewSet(viewsets.ModelViewSet):
             
             if tasks_list:
                 Task.objects.bulk_update(tasks_list, ['data'])
+                
+                # Clear the result field of UNLABELED annotations for these updated tasks
+                annotations_to_update = Annotation.objects.filter(
+                    task__in=tasks_list,
+                    annotation_status=UNLABELED
+                )
+                annotations_list = []
+                for annotation in annotations_to_update:
+                    if annotation.result:
+                        annotation.result = []
+                        annotations_list.append(annotation)
+                
+                if annotations_list:
+                    Annotation.objects.bulk_update(annotations_list, ['result'])
                 
             return Response({
                 "message": f"Updated {updated_count} incomplete tasks to model {new_model}.",

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1266,9 +1266,14 @@ class ProjectViewSet(viewsets.ModelViewSet):
                 )
                 annotations_list = []
                 for annotation in annotations_to_update:
-                    if annotation.result:
-                        annotation.result = []
-                        annotations_list.append(annotation)
+                    if annotation.result and isinstance(annotation.result, list):
+                        modified = False
+                        for item in annotation.result:
+                            if isinstance(item, dict) and "output" in item:
+                                item["output"] = ""
+                                modified = True
+                        if modified:
+                            annotations_list.append(annotation)
                 
                 if annotations_list:
                     Annotation.objects.bulk_update(annotations_list, ['result'])


### PR DESCRIPTION
### Summary
Added a new bulk update endpoint at the project level settings to automatically update `INCOMPLETE` tasks in `InstructionDrivenChat` projects that are currently assigned an inactive model, reallocating them to a selected active model. This prevents data leads from having to manually deallocate and reallocate unlabeled tasks when a model is deprecated.

### Changes
#### `backend/projects/views.py`
- Added `@action` endpoint `update_idc_tasks_model` to `ProjectViewSet`.
- **Permissions Validation:** Restricts execution to Organization Owners, Superusers, and Workspace Managers.
- **Payload Validation:** Extracts `new_model` from the POST request payload and validates that the requested model exists in `dataset.models.ACTIVE_LLM_MODELS`.
- **Project Validation:** Ensures the request is specifically for an `InstructionDrivenChat` project type.
- **Bulk Task Operations:** 
  - Retrieves all `INCOMPLETE` tasks for the project.
  - Efficiently compares `task.data["model"]` against `ACTIVE_LLM_MODELS`.
  - Reassigns the task's model to `new_model` if the current one is inactive.
  - Utilizes `Task.objects.bulk_update` to save the updated tasks efficiently and performantly.
- Merged latest updates from `dev` ensuring `ACTIVE_LLM_MODELS` list and model mappings are up to date.

### Testing
- Tested locally with existing Single IDC projects.
- Confirmed tasks with inactive models successfully update to an active model when the endpoint is called.
- Verified task status (`INCOMPLETE`) and project type (`InstructionDrivenChat`) filtering constraints.