### PR TITLE
Add OWASP Coraza WAF (CRS) reverse-proxy sidecar

### DIFF
--- a/coraza/README.md
+++ b/coraza/README.md
@@ -1,0 +1,97 @@
+# OWASP Coraza WAF (Core Rule Set)
+
+This directory wires an [OWASP Coraza](https://coraza.io/) Web Application
+Firewall running the [OWASP Core Rule Set (CRS)](https://coreruleset.org/) in
+front of the Django backend, using the CRS-maintained
+[`coraza-crs:nginx`](https://github.com/coreruleset/coraza-crs-docker) image.
+
+## Why this design (and not a compiled nginx module)
+
+Unlike ModSecurity, Coraza (written in Go) has **no drop-in module for stock
+nginx** — the `ngx_http_coraza_module` connector is experimental and would
+require rebuilding our `nginx` image from source against libcoraza. Instead we
+run the maintained CRS image as a **reverse-proxy sidecar**, which leaves our
+existing `nginx` + `certbot` (Let's Encrypt) stack completely untouched.
+
+## Request path
+
+```
+Before:  client ──TLS──► nginx:443 ──http──► web:8000
+After:   client ──TLS──► nginx:443 ──http──► coraza:8080 ──http──► web:8000
+                          (TLS + certbot)     (Coraza + OWASP CRS)   (gunicorn)
+```
+
+nginx keeps terminating TLS and managing Let's Encrypt. It then hands decrypted
+HTTP to Coraza, which inspects the request against the CRS and forwards clean
+traffic to the app. Static files served directly by nginx bypass the WAF (fine —
+they need no inspection and it keeps WAF load down).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `custom-rules.conf` | Site-specific rules + false-positive exclusions. Mounted at `/opt/coraza/rules.d/999-custom-rules.conf`, loaded **alongside** the bundled CRS. |
+| `README.md` | This document. |
+
+WAF behaviour is otherwise controlled via environment variables on the `coraza`
+service in `docker-compose-prod.yml` / `docker-compose-dev.yml` (see that block).
+
+## ⚠️ Enabling the WAF is a TWO-part change
+
+Adding the `coraza` service to compose is **additive and non-breaking** — by
+itself it does **not** route any traffic through the WAF. It just starts an idle
+container. To actually put the WAF in the request path you must **repoint the
+server-side vhost** (the `./vhosts/<domain>.conf` files live on the server, not
+in this repo):
+
+```nginx
+location / {
+    proxy_pass http://coraza:8080;              # was: http://web:8000
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+# keep `location /static/ { ... }` pointing at nginx — it bypasses the WAF
+```
+
+Passing `X-Real-IP` / `X-Forwarded-For` lets CRS rules and audit logs see the
+real client IP instead of nginx's internal address.
+
+## Rollout (do not skip)
+
+The service ships with `CORAZA_RULE_ENGINE=DetectionOnly` — the WAF **logs** what
+it *would* block but blocks nothing. Follow this order:
+
+1. **Deploy in DetectionOnly** and repoint the vhost. Watch the WAF logs:
+   `docker compose logs -f coraza`
+2. **Exercise real flows** (LLM/streaming endpoints, file uploads, admin) and
+   collect false positives (rule IDs + paths) from the audit log.
+3. **Tune** — add exclusions to `custom-rules.conf`, then
+   `docker compose up -d --force-recreate coraza`.
+4. **Enable blocking** — set `CORAZA_RULE_ENGINE: "On"` and recreate the
+   container. Only then consider raising `PARANOIA` to `2`.
+
+## Project-specific things to verify in DetectionOnly first
+
+- **Streaming / SSE**: this backend streams LLM responses. Confirm the WAF proxy
+  does not buffer or break chunked / server-sent-event responses before enabling
+  blocking.
+- **Uploads**: check `SecRequestBodyLimit` (see the example in
+  `custom-rules.conf`) against your file-upload endpoints so large uploads aren't
+  rejected.
+
+## Key environment variables
+
+| Var | Default here | Meaning |
+|-----|--------------|---------|
+| `BACKEND` | `web:8000` | Upstream app (`host:port`, no scheme). |
+| `PORT` | `8080` | Port the WAF listens on. |
+| `CORAZA_RULE_ENGINE` | `DetectionOnly` | `On` = block, `DetectionOnly` = log-only, `Off`. |
+| `PARANOIA` | `1` | CRS detection paranoia (higher = stricter, more false positives). |
+| `BLOCKING_PARANOIA` | `1` | Paranoia level that actually blocks. |
+| `ANOMALY_INBOUND` / `ANOMALY_OUTBOUND` | `5` / `4` | Anomaly-score block thresholds. |
+| `CORAZA_AUDIT_LOG` | `/dev/stdout` | Audit log destination (visible via `docker logs`). |
+
+See the [image documentation](https://github.com/coreruleset/coraza-crs-docker)
+for the full list.

--- a/coraza/custom-rules.conf
+++ b/coraza/custom-rules.conf
@@ -1,0 +1,30 @@
+# ---------------------------------------------------------------------------
+# Custom Coraza / OWASP CRS rules & false-positive exclusions
+# ---------------------------------------------------------------------------
+# Mounted into the WAF container at: /opt/coraza/rules.d/999-custom-rules.conf
+# It is loaded ALONGSIDE (not instead of) the bundled OWASP Core Rule Set.
+# The "999-" prefix ensures it loads AFTER the CRS rules.
+#
+# Purpose:
+#   * Silence false positives discovered during the DetectionOnly phase.
+#   * Add site-specific hardening rules.
+#
+# Syntax: SecLang / ModSecurity (Coraza is CRS-compatible). After editing,
+# recreate the container:  docker compose up -d --force-recreate coraza
+# ---------------------------------------------------------------------------
+
+# --- Example: disable a specific CRS rule globally (by rule id) ---
+# SecRuleRemoveById 920350
+
+# --- Example: disable a rule only for a specific path (e.g. an LLM/streaming
+#     endpoint that trips a rule on legitimate free-text prompts) ---
+# SecRule REQUEST_URI "@beginsWith /api/streaming/" \
+#     "id:1000001,phase:1,pass,nolog,ctl:ruleRemoveById=942100"
+
+# --- Example: exclude a specific argument from a specific rule ---
+# SecRuleUpdateTargetById 942100 "!ARGS:prompt"
+
+# --- Example: raise the request-body size limit for large file uploads (bytes) ---
+# SecRequestBodyLimit 26214400
+
+# Add your tuned exclusions below this line.

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -17,6 +17,33 @@ services:
       - "443:443"
     restart: unless-stopped
 
+  # OWASP Coraza WAF (OWASP Core Rule Set) — reverse proxy in front of the app.
+  # Request path once enabled:
+  #   client --TLS--> nginx --http--> coraza (WAF) --http--> web:8000
+  # This service is ADDITIVE: adding it does NOT reroute traffic by itself.
+  # To route through the WAF, repoint the server-side vhost proxy_pass from
+  # http://web:8000 to http://coraza:8080 (see coraza/README.md).
+  coraza:
+    image: ghcr.io/coreruleset/coraza-crs:nginx
+    restart: unless-stopped
+    environment:
+      BACKEND: "web:8000"                  # upstream app (host:port, no scheme)
+      PORT: "8080"                         # WAF listen port
+      CORAZA_RULE_ENGINE: "DetectionOnly"  # log-only; switch to "On" after tuning
+      PARANOIA: "1"
+      BLOCKING_PARANOIA: "1"
+      ANOMALY_INBOUND: "5"
+      ANOMALY_OUTBOUND: "4"
+      ACCESSLOG: "/dev/stdout"
+      ERRORLOG: "/dev/stderr"
+      CORAZA_AUDIT_LOG: "/dev/stdout"      # audit log visible via `docker logs`
+      LOGLEVEL: "warn"
+    volumes:
+      # Custom rules & false-positive exclusions, loaded alongside CRS defaults
+      - ./coraza/custom-rules.conf:/opt/coraza/rules.d/999-custom-rules.conf:ro
+    depends_on:
+      - web
+
   certbot:
     build: ./certbot
     image: evgeniy-khyst/certbot

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -17,6 +17,33 @@ services:
       - "443:443"
     restart: unless-stopped
 
+  # OWASP Coraza WAF (OWASP Core Rule Set) — reverse proxy in front of the app.
+  # Request path once enabled:
+  #   client --TLS--> nginx --http--> coraza (WAF) --http--> web:8000
+  # This service is ADDITIVE: adding it does NOT reroute traffic by itself.
+  # To route through the WAF, repoint the server-side vhost proxy_pass from
+  # http://web:8000 to http://coraza:8080 (see coraza/README.md).
+  coraza:
+    image: ghcr.io/coreruleset/coraza-crs:nginx
+    restart: unless-stopped
+    environment:
+      BACKEND: "web:8000"                  # upstream app (host:port, no scheme)
+      PORT: "8080"                         # WAF listen port
+      CORAZA_RULE_ENGINE: "DetectionOnly"  # log-only; switch to "On" after tuning
+      PARANOIA: "1"
+      BLOCKING_PARANOIA: "1"
+      ANOMALY_INBOUND: "5"
+      ANOMALY_OUTBOUND: "4"
+      ACCESSLOG: "/dev/stdout"
+      ERRORLOG: "/dev/stderr"
+      CORAZA_AUDIT_LOG: "/dev/stdout"      # audit log visible via `docker logs`
+      LOGLEVEL: "warn"
+    volumes:
+      # Custom rules & false-positive exclusions, loaded alongside CRS defaults
+      - ./coraza/custom-rules.conf:/opt/coraza/rules.d/999-custom-rules.conf:ro
+    depends_on:
+      - web
+
   certbot:
     build: ./certbot
     image: evgeniy-khyst/certbot


### PR DESCRIPTION
## What
Integrates an **OWASP Coraza** WAF running the **OWASP Core Rule Set (CRS)** in front of the Django backend, using the CRS-maintained `coraza-crs:nginx` image as a reverse-proxy sidecar. The existing nginx + certbot (Let's Encrypt) stack is untouched — Coraza (Go) has no production-ready module for stock nginx, so a sidecar is the maintained path.

Request path once enabled:
`client --TLS--> nginx --http--> coraza (WAF) --http--> web:8000`

## Changes
- Add `coraza` service to `docker-compose-prod.yml` and `docker-compose-dev.yml` (env-configured: `BACKEND=web:8000`, `CORAZA_RULE_ENGINE=DetectionOnly`, CRS paranoia/anomaly thresholds, logs to stdout/stderr).
- `coraza/custom-rules.conf` — false-positive exclusion template, mounted alongside the bundled CRS.
- `coraza/README.md` — architecture, rollout steps, and the required server-side vhost change.

## Additive / non-breaking
Merging this only adds an **idle, DetectionOnly** WAF container. It does **not** reroute traffic by itself. To route through the WAF, repoint the server-side vhost `proxy_pass` from `http://web:8000` to `http://coraza:8080` (see `coraza/README.md`). The `vhosts/*.conf` files live on the server, not in this repo.

## Rollout
1. Deploy in DetectionOnly + repoint the vhost.
2. Watch `docker compose logs -f coraza`; exercise real flows (LLM streaming, uploads, admin).
3. Add exclusions to `coraza/custom-rules.conf`.
4. Flip `CORAZA_RULE_ENGINE: "On"` to start blocking.

## Verify before enabling blocking
- SSE / streaming LLM responses aren't buffered or broken by the WAF proxy.
- `SecRequestBodyLimit` vs. file-upload endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
