### PR TITLE
fix: handle LLM errors and implement backend blank_response support

### DIFF
--- a/backend/functions/views.py
+++ b/backend/functions/views.py
@@ -2,6 +2,8 @@ import ast
 import json
 import os
 import uuid
+import logging
+logger = logging.getLogger(__name__)
 from azure.storage.blob import BlobServiceClient
 
 from anudesh_backend.locks import Lock
@@ -470,7 +472,14 @@ async def chat_output_stream(request):
                     continue
                 yield f"data: {json.dumps({'token': token, 'model': model})}\n\n"
         except Exception as e:
-            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+            status_code = getattr(e, "status_code", None)
+            if status_code == 402 or "402" in str(e):
+                logger.error(f"402 Error in chat stream view: {e}", exc_info=True)
+                yield f"data: {json.dumps({'error': 'The model is temporarily unavailable'})}\n\n"
+            elif "EngineCore encountered" in str(e):
+                yield f"data: {json.dumps({'error': 'The model is temporarily unavailable — please resend.'})}\n\n"
+            else:
+                yield f"data: {json.dumps({'error': str(e)})}\n\n"
         yield f"data: {json.dumps({'done': True, 'finish_reason': finish_reason})}\n\n"
 
     response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
@@ -511,7 +520,14 @@ async def chat_output_stream_multi(request):
             ):
                 yield f"data: {json.dumps(item)}\n\n"
         except Exception as e:
-            yield f"data: {json.dumps({'error': str(e)})}\n\n"
+            status_code = getattr(e, "status_code", None)
+            if status_code == 402 or "402" in str(e):
+                logger.error(f"402 Error in multi-model stream view: {e}", exc_info=True)
+                yield f"data: {json.dumps({'error': 'The model is temporarily unavailable'})}\n\n"
+            elif "EngineCore encountered" in str(e):
+                yield f"data: {json.dumps({'error': 'The model is temporarily unavailable — please resend.'})}\n\n"
+            else:
+                yield f"data: {json.dumps({'error': str(e)})}\n\n"
         yield f"data: {json.dumps({'done': True})}\n\n"
 
     response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -1707,19 +1707,7 @@ class AnnotationViewSet(
             ret_status = status.HTTP_404_NOT_FOUND
             return Response(final_result, status=ret_status)
 
-        if "result" in request.data:
-            result = request.data["result"]
-            project_metadata = task.project_id.metadata_json
-            if isinstance(project_metadata, dict) and project_metadata.get("blank_response") == True:
-                if isinstance(result, list):
-                    for turn in result:
-                        if isinstance(turn, dict) and "output" in turn:
-                            if isinstance(turn["output"], str):
-                                turn["output"] = ""
-                            elif isinstance(turn["output"], list):
-                                for model_out in turn["output"]:
-                                    if isinstance(model_out, dict) and "output" in model_out:
-                                        model_out["output"] = [{"type": "text", "value": ""}]
+
         try:
             if str(task.id) != str(request.data["task_id"]):
                 return Response(

--- a/backend/tasks/views.py
+++ b/backend/tasks/views.py
@@ -1706,6 +1706,20 @@ class AnnotationViewSet(
             final_result = {"message": "annotation object does not exist!"}
             ret_status = status.HTTP_404_NOT_FOUND
             return Response(final_result, status=ret_status)
+
+        if "result" in request.data:
+            result = request.data["result"]
+            project_metadata = task.project_id.metadata_json
+            if isinstance(project_metadata, dict) and project_metadata.get("blank_response") == True:
+                if isinstance(result, list):
+                    for turn in result:
+                        if isinstance(turn, dict) and "output" in turn:
+                            if isinstance(turn["output"], str):
+                                turn["output"] = ""
+                            elif isinstance(turn["output"], list):
+                                for model_out in turn["output"]:
+                                    if isinstance(model_out, dict) and "output" in model_out:
+                                        model_out["output"] = [{"type": "text", "value": ""}]
         try:
             if str(task.id) != str(request.data["task_id"]):
                 return Response(

--- a/backend/utils/llm_interactions.py
+++ b/backend/utils/llm_interactions.py
@@ -1,4 +1,6 @@
 import os
+import logging
+logger = logging.getLogger(__name__)
 
 # https://pypi.org/project/openai/
 # import openai
@@ -370,7 +372,14 @@ async def stream_google_ai_studio_output(system_prompt, user_prompt, history, mo
                 if chunk.choices[0].finish_reason:
                     finish_reason = chunk.choices[0].finish_reason
     except Exception as e:
-        yield f"[ERROR] {e}"
+        status_code = getattr(e, "status_code", None)
+        if status_code == 402 or "402" in str(e):
+            logger.error(f"402 Error in Google AI Studio stream: {e}", exc_info=True)
+            yield "[ERROR] The model is temporarily unavailable"
+        elif "EngineCore encountered" in str(e):
+            yield "[ERROR] The model is temporarily unavailable — please resend."
+        else:
+            yield f"[ERROR] {e}"
         return
     # Yield a sentinel so callers can extract the finish_reason
     yield {"__finish_reason__": finish_reason}
@@ -432,7 +441,14 @@ async def stream_deepinfra_output(system_prompt, user_prompt, history, model):
         if pending and not in_think:
             yield pending.lstrip("\n")
     except Exception as e:
-        yield f"[ERROR] {e}"
+        status_code = getattr(e, "status_code", None)
+        if status_code == 402 or "402" in str(e):
+            logger.error(f"402 Error in DeepInfra stream: {e}", exc_info=True)
+            yield "[ERROR] The model is temporarily unavailable"
+        elif "EngineCore encountered" in str(e):
+            yield "[ERROR] The model is temporarily unavailable — please resend."
+        else:
+            yield f"[ERROR] {e}"
         return
     # Yield a sentinel so callers can extract the finish_reason
     yield {"__finish_reason__": finish_reason}


### PR DESCRIPTION
## Description
This PR addresses backend issues related to translation and logging of LLM generation exceptions (specifically 402 payment errors and EngineCore failures) as well as setting up basic backend support and sanitation checks for the project-level `blank_response` configuration.

## Key Changes

### 1. Error Translation & Logging
* **Logging and Capturing 402 Errors**:
  * Intercepted exceptions in standard/multi-model chat streams (`chat_output_stream` and `chat_output_stream_multi` in `backend/functions/views.py`) and provider generation functions (`stream_google_ai_studio_output` and `stream_deepinfra_output` in `backend/utils/llm_interactions.py`).
  * If a payment/billing `402` error or related message is caught, the full traceback is safely logged on the server using `logger.error` (for administrator visibility) while sending a clean, user-friendly error string (`"The model is temporarily unavailable"`) back to the client.
* **EngineCore Failure Masking**:
  * If the exception contains `"EngineCore encountered"`, it is translated to `"The model is temporarily unavailable — please resend."` in SSE streams to match client requirements and prevent stack traces from leaking directly into the UI.

### 2. Blank Response Support on Save
* **Sanitation Guard in `AnnotationViewSet.partial_update`**:
  * Intercepts incoming patch payloads for projects where `blank_response` is enabled in `metadata_json`.
  * Enforces blank outputs (`""` or empty string dictionaries) for both single-model string records and multi-model list records before committing them to the database.

---

## Verification & Compilation Results
* Switched to python compile validator and confirmed all changes in `backend/functions/views.py`, `backend/utils/llm_interactions.py`, and `backend/tasks/views.py` compile successfully.
